### PR TITLE
add docker-related files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Node dependencies - rebuilt inside the container
+node_modules
+
+# Build output (will be generated automatically during build)
+dist
+
+# NPM/Yarn/PNPM lock files (optional, but useful if you use `COPY package*.json`)
+npm-debug.log
+yarn-error.log
+pnpm-lock.yaml
+
+# Docker-related config files
+Dockerfile*
+docker-compose*
+.dockerignore
+
+# Git-related files
+.git/
+.gitignore
+
+# Environment and secrets
+.env
+.env.local
+
+# IDE/editor/project configs
+.vscode/
+.idea/
+
+# OS and temp files
+.DS_Store
+Thumbs.db
+
+# Not needed inside container
+README.md

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,12 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
   // // Uncomment this and update according you needs
   // overrides: [{

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+# Prune dev dependencies AFTER build
+RUN npm prune --omit=dev
+
+# Production stage
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+
+ENV NODE_ENV=production
+
+EXPOSE 4000
+
+CMD ["node", "dist/main"]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "docker:build": "docker build -t cart-service .",
+    "docker:run": "docker run -p 4000:4000 cart-service",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
**Task:** https://github.com/rolling-scopes-school/aws/blob/main/aws-developer/09_containerization/task.md

All mandatory requirements for achieving score 100 were completed: Dockerfile was created, image size is less than 500MB (got 172MB), redundant files and folders were omitted with .dockerignore. Cart application was deployed with Elastic Beanstalk. Links on frontend app were adjusted as well (FE app isn't deployed as it's an optional task and doesn't effect the score).

Please keep in mind, that I didn't use RDS for this task since it's not free for my account - contrariwise it's quite costly. That's why I use initial version of cart app from forked repo. For this task it shouldn't be a problem since the task is only about docker and eb.

**Links:**
FE PR: https://github.com/AndrewZanko/nodejs-aws-shop-react/pull/5
Cart API: http://AndrewZanko-cart-api-prod.eu-west-1.elasticbeanstalk.com

**Screenshots:**

docker image:
![image](https://github.com/user-attachments/assets/50fe8d39-07c5-4dd5-b7b0-fe16a47f60eb)

using eb cli:
![image](https://github.com/user-attachments/assets/c2fe5966-8b62-4ea5-87a7-bc147242736d)

application in aws console:
![image](https://github.com/user-attachments/assets/d54dd4fe-8d4b-4a37-bc4d-7302ac3c538a)

calling api from postman:
![image](https://github.com/user-attachments/assets/5dca7e24-e900-484f-b829-b378fca2d40a)

**Done:** 13.04.2025 / deadline 14.04.2025
**Score:** 100 / 100

